### PR TITLE
JSONObserver: loglevel and empty files

### DIFF
--- a/chia/instrumentation/observers/json_observer.py
+++ b/chia/instrumentation/observers/json_observer.py
@@ -23,7 +23,7 @@ class JSONObserver(Observer):
         experiment_metadata=None,
         environment_info=None,
         path_pattern="results/%s/%s.json.gz",
-        log_level=logging.WARNING,
+        log_level=logging.DEBUG,
         compress=True,
     ):
         # Deal with potential nonexistant metadata

--- a/chia/instrumentation/observers/json_observer.py
+++ b/chia/instrumentation/observers/json_observer.py
@@ -55,6 +55,9 @@ class JSONObserver(Observer):
         with open(self.path, "w") as f:
             f.write("{}")
 
+        # Remove the file again because it might irritate version control and be interpreted as .gz
+        pathlib.Path(self.path).unlink()
+
         self.valid_messages = {
             filter_element.__name__: []
             for filter_element in list(self.message_filter)


### PR DESCRIPTION
* JSONObserver: Don't keep files with only {} in them
* JSONObserver: Change default log level to DEBUG