### PR TITLE
Workflows: Attempt fixing black dependencies

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -23,7 +23,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest black coverage
+        pip install black
+        pip install flake8 pytest coverage
         pip install -e .
     - name: Lint with flake8
       run: |

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -25,7 +25,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install black
         pip install flake8 pytest coverage
-        pip install -e .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -38,6 +37,7 @@ jobs:
         black --check chia tests setup.py
     - name: Test with pytest and coverage
       run: |
+        pip install -e .
         coverage run --source chia --branch -m pytest
     - name: Codecov
       uses: codecov/codecov-action@v1.0.13


### PR DESCRIPTION
Install black before flake8 etc. to (hopefully) get the correct version of typing-extensions which currently causes #54 to fail checks.